### PR TITLE
Feature-6 setuping up flutter flavors  ✨

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,3 +21,5 @@ This pull request includes the following changes:
 | 01                                    | 02                                    | 03                                    | 04                                    |
 | ------------------------------------- | ------------------------------------- | ------------------------------------- | ------------------------------------- |
 | <img src="" width="100" height="250"> | <img src="" width="100" height="250"> | <img src="" width="100" height="250"> | <img src="" width="100" height="250"> |
+
+## How to test 🚦

--- a/mobile_app/.vscode/launch.json
+++ b/mobile_app/.vscode/launch.json
@@ -6,14 +6,19 @@
       "request": "launch",
       "type": "dart",
       "program": "lib/main_development.dart",
-      "args": ["--target", "lib/main_development.dart"]
+      "args": [
+        "--flavor",
+        "development",
+        "--target",
+        "lib/main_development.dart"
+      ]
     },
     {
       "name": "Chat Production",
       "request": "launch",
       "type": "dart",
       "program": "lib/main_production.dart",
-      "args": ["--target", "lib/main_production.dart"]
+      "args": ["--flavor", "production", "--target", "lib/main_production.dart"]
     }
   ]
 }

--- a/mobile_app/android/app/build.gradle
+++ b/mobile_app/android/app/build.gradle
@@ -24,7 +24,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace = "com.example.mobile_app"
+    namespace = "com.attraxia.chat_app"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -35,13 +35,28 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.mobile_app"
+        applicationId "com.attraxia.chat_app"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutterVersionCode.toInteger()
         versionName = flutterVersionName
+    }
+
+    flavorDimensions "default"
+
+    productFlavors {
+    production {
+        dimension "default"
+        resValue "string", "app_name", "Chat App"
+    }
+
+    development {
+        dimension "default"
+        resValue "string", "app_name", "Chat App Dev"
+        applicationIdSuffix ".dev"
+    }
     }
 
     buildTypes {

--- a/mobile_app/android/app/src/main/AndroidManifest.xml
+++ b/mobile_app/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="mobile_app"
+        android:label="@string/app_name"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/mobile_app/android/app/src/main/kotlin/com/attraxia/chat_app/MainActivity.kt
+++ b/mobile_app/android/app/src/main/kotlin/com/attraxia/chat_app/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.mobile_app
+package com.attraxia.chat_app
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/mobile_app/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile_app/ios/Runner.xcodeproj/project.pbxproj
@@ -368,7 +368,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.mobileApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.attraxia.chat_app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -384,7 +384,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.mobileApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.attraxia.chat_app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -401,7 +401,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.mobileApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.attraxia.chat_app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -416,7 +416,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.mobileApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.attraxia.chat_app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -547,7 +547,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.mobileApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.attraxia.chat_app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -569,7 +569,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.mobileApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.attraxia.chat_app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/mobile_app/lib/main_production.dart
+++ b/mobile_app/lib/main_production.dart
@@ -1,1 +1,10 @@
-// we do not have a specific server for production 
+//? we do not have a specific setup for production environment yet :(
+
+import 'package:flutter/material.dart';
+
+import 'chat_app.dart';
+import 'core/routing/app_router.dart';
+
+void main() {
+  runApp(ChatApp(appRouter: AppRouter()));
+}


### PR DESCRIPTION


## JiraTicket [FI-6](https://contributors.atlassian.net/jira/software/projects/ATX/boards/6?selectedIssue=ATX-6)

## Description 📑
Setuping up flutter flavors to enable running the app with different build configurations development and production for future use

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] 🏗️ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore

## Changes

This pull request includes the following changes:
- setup flutter flavors for android
- change app package id to com.attraxia.chat_app
- add code to enable running the app from the production main same as development
- update pull request template with adding how to test part
## Screenshots 📷

| prod/dev apps                                    |
| ------------------------------------- |
| <img src="https://github.com/user-attachments/assets/b4bae1f9-f999-474d-9a7f-e00502791c90" width="100" height="250"> |

## How to test 🚦
- need to run the development and production build type of the app, can be done easly with vscode, as result we should have 2 different apps with different name