### PR TITLE
9- feature integrate chat api ✨

### DIFF
--- a/mobile_app/lib/core/di/dependency_injection.dart
+++ b/mobile_app/lib/core/di/dependency_injection.dart
@@ -1,5 +1,16 @@
 import 'package:get_it/get_it.dart';
+import 'package:mobile_app/features/chat/data/repositories/chat_repository.dart';
+import 'package:mobile_app/features/chat/logic/bloc/chat_bloc.dart';
+
+import '../../features/chat/data/data_source/chat_remote_data_source.dart';
 
 final getIt = GetIt.instance;
 
-Future<void> setupGetIt() async {}
+Future<void> setupGetIt() async {
+  // chat
+  getIt.registerLazySingleton<ChatBloc>(() => ChatBloc(getIt()));
+  getIt.registerLazySingleton<ChatRepository>(
+      () => ChatRepositoryImplementation(getIt()));
+  getIt.registerLazySingleton<ChatRemoteDataSource>(
+      () => ChatRemoteDataSourceImplementation());
+}

--- a/mobile_app/lib/core/enums/user_enums.dart
+++ b/mobile_app/lib/core/enums/user_enums.dart
@@ -1,0 +1,1 @@
+enum User { younes, ali }

--- a/mobile_app/lib/core/networking/api_result.dart
+++ b/mobile_app/lib/core/networking/api_result.dart
@@ -1,0 +1,8 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'api_result.freezed.dart';
+
+@Freezed()
+abstract class ApiResult<T> with _$ApiResult<T> {
+  const factory ApiResult.success(T data) = Success<T>;
+  const factory ApiResult.failure(String error) = Failure<T>;
+}

--- a/mobile_app/lib/core/networking/api_result.freezed.dart
+++ b/mobile_app/lib/core/networking/api_result.freezed.dart
@@ -1,0 +1,342 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'api_result.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$ApiResult<T> {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(T data) success,
+    required TResult Function(String error) failure,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(T data)? success,
+    TResult? Function(String error)? failure,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(T data)? success,
+    TResult Function(String error)? failure,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Success<T> value) success,
+    required TResult Function(Failure<T> value) failure,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(Success<T> value)? success,
+    TResult? Function(Failure<T> value)? failure,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Success<T> value)? success,
+    TResult Function(Failure<T> value)? failure,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ApiResultCopyWith<T, $Res> {
+  factory $ApiResultCopyWith(
+          ApiResult<T> value, $Res Function(ApiResult<T>) then) =
+      _$ApiResultCopyWithImpl<T, $Res, ApiResult<T>>;
+}
+
+/// @nodoc
+class _$ApiResultCopyWithImpl<T, $Res, $Val extends ApiResult<T>>
+    implements $ApiResultCopyWith<T, $Res> {
+  _$ApiResultCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$SuccessImplCopyWith<T, $Res> {
+  factory _$$SuccessImplCopyWith(
+          _$SuccessImpl<T> value, $Res Function(_$SuccessImpl<T>) then) =
+      __$$SuccessImplCopyWithImpl<T, $Res>;
+  @useResult
+  $Res call({T data});
+}
+
+/// @nodoc
+class __$$SuccessImplCopyWithImpl<T, $Res>
+    extends _$ApiResultCopyWithImpl<T, $Res, _$SuccessImpl<T>>
+    implements _$$SuccessImplCopyWith<T, $Res> {
+  __$$SuccessImplCopyWithImpl(
+      _$SuccessImpl<T> _value, $Res Function(_$SuccessImpl<T>) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? data = freezed,
+  }) {
+    return _then(_$SuccessImpl<T>(
+      freezed == data
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as T,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SuccessImpl<T> implements Success<T> {
+  const _$SuccessImpl(this.data);
+
+  @override
+  final T data;
+
+  @override
+  String toString() {
+    return 'ApiResult<$T>.success(data: $data)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SuccessImpl<T> &&
+            const DeepCollectionEquality().equals(other.data, data));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(data));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SuccessImplCopyWith<T, _$SuccessImpl<T>> get copyWith =>
+      __$$SuccessImplCopyWithImpl<T, _$SuccessImpl<T>>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(T data) success,
+    required TResult Function(String error) failure,
+  }) {
+    return success(data);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(T data)? success,
+    TResult? Function(String error)? failure,
+  }) {
+    return success?.call(data);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(T data)? success,
+    TResult Function(String error)? failure,
+    required TResult orElse(),
+  }) {
+    if (success != null) {
+      return success(data);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Success<T> value) success,
+    required TResult Function(Failure<T> value) failure,
+  }) {
+    return success(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(Success<T> value)? success,
+    TResult? Function(Failure<T> value)? failure,
+  }) {
+    return success?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Success<T> value)? success,
+    TResult Function(Failure<T> value)? failure,
+    required TResult orElse(),
+  }) {
+    if (success != null) {
+      return success(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Success<T> implements ApiResult<T> {
+  const factory Success(final T data) = _$SuccessImpl<T>;
+
+  T get data;
+  @JsonKey(ignore: true)
+  _$$SuccessImplCopyWith<T, _$SuccessImpl<T>> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$FailureImplCopyWith<T, $Res> {
+  factory _$$FailureImplCopyWith(
+          _$FailureImpl<T> value, $Res Function(_$FailureImpl<T>) then) =
+      __$$FailureImplCopyWithImpl<T, $Res>;
+  @useResult
+  $Res call({String error});
+}
+
+/// @nodoc
+class __$$FailureImplCopyWithImpl<T, $Res>
+    extends _$ApiResultCopyWithImpl<T, $Res, _$FailureImpl<T>>
+    implements _$$FailureImplCopyWith<T, $Res> {
+  __$$FailureImplCopyWithImpl(
+      _$FailureImpl<T> _value, $Res Function(_$FailureImpl<T>) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? error = null,
+  }) {
+    return _then(_$FailureImpl<T>(
+      null == error
+          ? _value.error
+          : error // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$FailureImpl<T> implements Failure<T> {
+  const _$FailureImpl(this.error);
+
+  @override
+  final String error;
+
+  @override
+  String toString() {
+    return 'ApiResult<$T>.failure(error: $error)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$FailureImpl<T> &&
+            (identical(other.error, error) || other.error == error));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, error);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$FailureImplCopyWith<T, _$FailureImpl<T>> get copyWith =>
+      __$$FailureImplCopyWithImpl<T, _$FailureImpl<T>>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(T data) success,
+    required TResult Function(String error) failure,
+  }) {
+    return failure(error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(T data)? success,
+    TResult? Function(String error)? failure,
+  }) {
+    return failure?.call(error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(T data)? success,
+    TResult Function(String error)? failure,
+    required TResult orElse(),
+  }) {
+    if (failure != null) {
+      return failure(error);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Success<T> value) success,
+    required TResult Function(Failure<T> value) failure,
+  }) {
+    return failure(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(Success<T> value)? success,
+    TResult? Function(Failure<T> value)? failure,
+  }) {
+    return failure?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Success<T> value)? success,
+    TResult Function(Failure<T> value)? failure,
+    required TResult orElse(),
+  }) {
+    if (failure != null) {
+      return failure(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Failure<T> implements ApiResult<T> {
+  const factory Failure(final String error) = _$FailureImpl<T>;
+
+  String get error;
+  @JsonKey(ignore: true)
+  _$$FailureImplCopyWith<T, _$FailureImpl<T>> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/mobile_app/lib/core/networking/firebase_constants.dart
+++ b/mobile_app/lib/core/networking/firebase_constants.dart
@@ -1,0 +1,7 @@
+class FirebaseConstants {
+  static String chatCollection = 'chat';
+  static Map<String, dynamic> newChatCollection = <String, dynamic>{
+    'aliUnSeenMessagesCount': 0,
+    'younesUnSeenMessagesCount': 0,
+  };
+}

--- a/mobile_app/lib/core/routing/app_router.dart
+++ b/mobile_app/lib/core/routing/app_router.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:mobile_app/core/di/dependency_injection.dart';
 import 'package:mobile_app/features/chat/logic/bloc/chat_bloc.dart';
 import 'package:mobile_app/features/conversation/ui/conversation_screen.dart';
 
@@ -17,7 +18,7 @@ class AppRouter {
         return MaterialPageRoute(
           builder: (_) => BlocProvider(
             create: (context) =>
-                ChatBloc()..add(const ChatEvent.getConversations()),
+                getIt<ChatBloc>()..add(const ChatEvent.getConversations()),
             child: const ChatScreen(),
           ),
         );

--- a/mobile_app/lib/features/chat/data/data_source/chat_remote_data_source.dart
+++ b/mobile_app/lib/features/chat/data/data_source/chat_remote_data_source.dart
@@ -1,0 +1,34 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:mobile_app/core/networking/firebase_constants.dart';
+import 'package:mobile_app/features/chat/data/models/conversation_model.dart';
+
+import '../../../../core/enums/user_enums.dart';
+
+abstract class ChatRemoteDataSource {
+  Future<void> startNewConversation();
+  Future<List<ConversationModel>> getConversations(User selectedUser);
+}
+
+class ChatRemoteDataSourceImplementation implements ChatRemoteDataSource {
+  @override
+  Future<void> startNewConversation() async {
+    CollectionReference conversation =
+        FirebaseFirestore.instance.collection(FirebaseConstants.chatCollection);
+    conversation.add(FirebaseConstants.newChatCollection);
+  }
+
+  @override
+  Future<List<ConversationModel>> getConversations(User selectedUser) async {
+    CollectionReference conversation =
+        FirebaseFirestore.instance.collection(FirebaseConstants.chatCollection);
+    QuerySnapshot querySnapshot = await conversation.get();
+    List<ConversationModel> conversations = [];
+
+    querySnapshot.docs.forEach((element) {
+      conversations.add(ConversationModel.fromJson(
+          {...element.data() as Map<String, dynamic>, 'id': element.id},
+          selectedUser));
+    });
+    return conversations;
+  }
+}

--- a/mobile_app/lib/features/chat/data/models/conversation_model.dart
+++ b/mobile_app/lib/features/chat/data/models/conversation_model.dart
@@ -1,3 +1,5 @@
+import '../../../../core/enums/user_enums.dart';
+
 class ConversationModel {
   final String id;
   final String name;
@@ -10,6 +12,30 @@ class ConversationModel {
     required this.unSeenMessagesCount,
     this.lastMessage,
   });
+
+  factory ConversationModel.fromJson(
+      Map<String, dynamic> json, User selectedUser) {
+    int unSeenMessagesCount;
+    String name;
+    switch (selectedUser) {
+      case User.younes:
+        unSeenMessagesCount = json['aliUnSeenMessagesCount'];
+        name = 'Ali';
+        break;
+      case User.ali:
+        unSeenMessagesCount = json['younesUnSeenMessagesCount'];
+        name = 'Younes';
+        break;
+    }
+    return ConversationModel(
+      id: json['id'],
+      name: name,
+      unSeenMessagesCount: unSeenMessagesCount,
+      lastMessage: json['lastMessage'] == null
+          ? null
+          : LastMessageModel.fromJson(json['lastMessage']),
+    );
+  }
 }
 
 class LastMessageModel {
@@ -20,4 +46,11 @@ class LastMessageModel {
     required this.message,
     required this.sentTime,
   });
+
+  factory LastMessageModel.fromJson(Map<String, dynamic> json) {
+    return LastMessageModel(
+      message: json['message'],
+      sentTime: DateTime.parse(json['sentTime']),
+    );
+  }
 }

--- a/mobile_app/lib/features/chat/data/repositories/chat_repository.dart
+++ b/mobile_app/lib/features/chat/data/repositories/chat_repository.dart
@@ -1,0 +1,37 @@
+import 'package:mobile_app/core/networking/api_result.dart';
+import 'package:mobile_app/features/chat/data/data_source/chat_remote_data_source.dart';
+import 'package:mobile_app/features/chat/data/models/conversation_model.dart';
+
+import '../../../../core/enums/user_enums.dart';
+
+abstract class ChatRepository {
+  Future<ApiResult<void>> startNewConversation();
+  Future<ApiResult<List<ConversationModel>>> getConversations(
+      User selectedUser);
+}
+
+class ChatRepositoryImplementation implements ChatRepository {
+  ChatRepositoryImplementation(this._chatRemoteDataSource);
+  final ChatRemoteDataSource _chatRemoteDataSource;
+  @override
+  Future<ApiResult<void>> startNewConversation() async {
+    try {
+      await _chatRemoteDataSource.startNewConversation();
+      return const ApiResult.success(null);
+    } catch (error) {
+      return ApiResult.failure(error.toString());
+    }
+  }
+
+  @override
+  Future<ApiResult<List<ConversationModel>>> getConversations(
+      User selectedUser) async {
+    try {
+      final conversation =
+          await _chatRemoteDataSource.getConversations(selectedUser);
+      return ApiResult.success(conversation);
+    } catch (error) {
+      return ApiResult.failure(error.toString());
+    }
+  }
+}

--- a/mobile_app/lib/features/chat/logic/bloc/chat_bloc.dart
+++ b/mobile_app/lib/features/chat/logic/bloc/chat_bloc.dart
@@ -1,32 +1,63 @@
+import 'dart:async';
+
 import 'package:bloc/bloc.dart';
 import 'package:bloc_concurrency/bloc_concurrency.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:mobile_app/core/enums/user_enums.dart';
 import 'package:mobile_app/core/helpers/extensions.dart';
+import 'package:mobile_app/core/networking/firebase_constants.dart';
 import 'package:mobile_app/core/routing/routes.dart';
 
 import '../../data/models/conversation_model.dart';
+import '../../data/repositories/chat_repository.dart';
 
 part 'chat_event.dart';
 part 'chat_state.dart';
 part 'chat_bloc.freezed.dart';
 
 class ChatBloc extends Bloc<ChatEvent, ChatState> {
-  ChatBloc() : super(const _Initial()) {
+  final ChatRepository _chatRepository;
+
+  final Stream<QuerySnapshot> _chatStream = FirebaseFirestore.instance
+      .collection(FirebaseConstants.chatCollection)
+      .snapshots();
+  StreamSubscription<QuerySnapshot>? chatSubscription;
+  User selectedUser = User.younes;
+
+  ChatBloc(this._chatRepository) : super(const _Initial()) {
     on<_GetConversations>(_getConversations);
+    on<_OnNewMessagesReceived>(_onNewMessagesReceived);
     on<_ChangeSelectedPage>(_changeSelectedPageIndex,
-        // prevent multiple events from being processed at the same time
-        transformer: restartable());
+        transformer:
+            restartable()); // prevent multiple events from being processed at the same time
     on<_OpenConversation>(_openConversation);
     on<_StartNewConversation>(_startNewConversation);
+  }
+
+  Future<void> _onNewMessagesReceived(
+    _OnNewMessagesReceived event,
+    Emitter<ChatState> emit,
+  ) async {
+    emit(Loaded(event.conversations));
   }
 
   Future<void> _getConversations(
     _GetConversations event,
     Emitter<ChatState> emit,
   ) async {
-    await Future.delayed(const Duration(seconds: 2));
-    emit(const Loaded([]));
+    chatSubscription = _chatStream.listen(
+      (event) {
+        final conversations = event.docs
+            .map((conversation) => ConversationModel.fromJson({
+                  ...conversation.data() as Map<String, dynamic>,
+                  'id': conversation.id,
+                }, selectedUser))
+            .toList();
+        add(ChatEvent.onNewMessagesReceived(conversations));
+      },
+    );
   }
 
   void _changeSelectedPageIndex(
@@ -34,41 +65,26 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
     Emitter<ChatState> emit,
   ) async {
     emit(ChangeSelectedPageIndex(event.pageIndex));
-    await Future.delayed(const Duration(seconds: 2));
-    emit(Loaded([
-      ConversationModel(
-        id: '1',
-        name: 'John Doe',
-        unSeenMessagesCount: 2,
-        lastMessage: LastMessageModel(
-          message: 'Hey',
-          sentTime: DateTime.now(),
-        ),
-      ),
-      ConversationModel(
-        id: '2',
-        name: 'Jane Doe',
-        unSeenMessagesCount: 0,
-        lastMessage: LastMessageModel(
-          message: 'Hi, I am fine',
-          sentTime: DateTime.now(),
-        ),
-      ),
-      ConversationModel(
-        id: '1',
-        name: 'John Doe',
-        unSeenMessagesCount: 1,
-        lastMessage: LastMessageModel(
-          message: 'Hey',
-          sentTime: DateTime.now(),
-        ),
-      ),
-      ConversationModel(
-        id: '2',
-        name: 'Jane Doe',
-        unSeenMessagesCount: 0,
-      ),
-    ]));
+    switch (event.pageIndex) {
+      case 0:
+        selectedUser = User.younes;
+
+      case 1:
+        selectedUser = User.ali;
+    }
+    chatSubscription?.cancel();
+    add(const ChatEvent.getConversations());
+  }
+
+  void _startNewConversation(
+    _StartNewConversation event,
+    Emitter<ChatState> emit,
+  ) async {
+    final response = await _chatRepository.startNewConversation();
+    response.when(
+      success: (_) => null,
+      failure: (error) => null,
+    );
   }
 
   void _openConversation(
@@ -81,10 +97,9 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
     });
   }
 
-  void _startNewConversation(
-    _StartNewConversation event,
-    Emitter<ChatState> emit,
-  ) {
-    // Start new conversation logic
+  @override
+  Future<void> close() {
+    chatSubscription?.cancel();
+    return super.close();
   }
 }

--- a/mobile_app/lib/features/chat/logic/bloc/chat_bloc.freezed.dart
+++ b/mobile_app/lib/features/chat/logic/bloc/chat_bloc.freezed.dart
@@ -24,6 +24,8 @@ mixin _$ChatEvent {
             BuildContext context, String conversationId, String userName)
         openConversation,
     required TResult Function() startNewConversation,
+    required TResult Function(List<ConversationModel> conversations)
+        onNewMessagesReceived,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -34,6 +36,8 @@ mixin _$ChatEvent {
             BuildContext context, String conversationId, String userName)?
         openConversation,
     TResult? Function()? startNewConversation,
+    TResult? Function(List<ConversationModel> conversations)?
+        onNewMessagesReceived,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -44,6 +48,8 @@ mixin _$ChatEvent {
             BuildContext context, String conversationId, String userName)?
         openConversation,
     TResult Function()? startNewConversation,
+    TResult Function(List<ConversationModel> conversations)?
+        onNewMessagesReceived,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -53,6 +59,8 @@ mixin _$ChatEvent {
     required TResult Function(_ChangeSelectedPage value) changeSelectedPage,
     required TResult Function(_OpenConversation value) openConversation,
     required TResult Function(_StartNewConversation value) startNewConversation,
+    required TResult Function(_OnNewMessagesReceived value)
+        onNewMessagesReceived,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -61,6 +69,7 @@ mixin _$ChatEvent {
     TResult? Function(_ChangeSelectedPage value)? changeSelectedPage,
     TResult? Function(_OpenConversation value)? openConversation,
     TResult? Function(_StartNewConversation value)? startNewConversation,
+    TResult? Function(_OnNewMessagesReceived value)? onNewMessagesReceived,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -69,6 +78,7 @@ mixin _$ChatEvent {
     TResult Function(_ChangeSelectedPage value)? changeSelectedPage,
     TResult Function(_OpenConversation value)? openConversation,
     TResult Function(_StartNewConversation value)? startNewConversation,
+    TResult Function(_OnNewMessagesReceived value)? onNewMessagesReceived,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -135,6 +145,8 @@ class _$GetConversationsImpl implements _GetConversations {
             BuildContext context, String conversationId, String userName)
         openConversation,
     required TResult Function() startNewConversation,
+    required TResult Function(List<ConversationModel> conversations)
+        onNewMessagesReceived,
   }) {
     return getConversations();
   }
@@ -148,6 +160,8 @@ class _$GetConversationsImpl implements _GetConversations {
             BuildContext context, String conversationId, String userName)?
         openConversation,
     TResult? Function()? startNewConversation,
+    TResult? Function(List<ConversationModel> conversations)?
+        onNewMessagesReceived,
   }) {
     return getConversations?.call();
   }
@@ -161,6 +175,8 @@ class _$GetConversationsImpl implements _GetConversations {
             BuildContext context, String conversationId, String userName)?
         openConversation,
     TResult Function()? startNewConversation,
+    TResult Function(List<ConversationModel> conversations)?
+        onNewMessagesReceived,
     required TResult orElse(),
   }) {
     if (getConversations != null) {
@@ -176,6 +192,8 @@ class _$GetConversationsImpl implements _GetConversations {
     required TResult Function(_ChangeSelectedPage value) changeSelectedPage,
     required TResult Function(_OpenConversation value) openConversation,
     required TResult Function(_StartNewConversation value) startNewConversation,
+    required TResult Function(_OnNewMessagesReceived value)
+        onNewMessagesReceived,
   }) {
     return getConversations(this);
   }
@@ -187,6 +205,7 @@ class _$GetConversationsImpl implements _GetConversations {
     TResult? Function(_ChangeSelectedPage value)? changeSelectedPage,
     TResult? Function(_OpenConversation value)? openConversation,
     TResult? Function(_StartNewConversation value)? startNewConversation,
+    TResult? Function(_OnNewMessagesReceived value)? onNewMessagesReceived,
   }) {
     return getConversations?.call(this);
   }
@@ -198,6 +217,7 @@ class _$GetConversationsImpl implements _GetConversations {
     TResult Function(_ChangeSelectedPage value)? changeSelectedPage,
     TResult Function(_OpenConversation value)? openConversation,
     TResult Function(_StartNewConversation value)? startNewConversation,
+    TResult Function(_OnNewMessagesReceived value)? onNewMessagesReceived,
     required TResult orElse(),
   }) {
     if (getConversations != null) {
@@ -283,6 +303,8 @@ class _$ChangeSelectedPageImpl implements _ChangeSelectedPage {
             BuildContext context, String conversationId, String userName)
         openConversation,
     required TResult Function() startNewConversation,
+    required TResult Function(List<ConversationModel> conversations)
+        onNewMessagesReceived,
   }) {
     return changeSelectedPage(pageIndex);
   }
@@ -296,6 +318,8 @@ class _$ChangeSelectedPageImpl implements _ChangeSelectedPage {
             BuildContext context, String conversationId, String userName)?
         openConversation,
     TResult? Function()? startNewConversation,
+    TResult? Function(List<ConversationModel> conversations)?
+        onNewMessagesReceived,
   }) {
     return changeSelectedPage?.call(pageIndex);
   }
@@ -309,6 +333,8 @@ class _$ChangeSelectedPageImpl implements _ChangeSelectedPage {
             BuildContext context, String conversationId, String userName)?
         openConversation,
     TResult Function()? startNewConversation,
+    TResult Function(List<ConversationModel> conversations)?
+        onNewMessagesReceived,
     required TResult orElse(),
   }) {
     if (changeSelectedPage != null) {
@@ -324,6 +350,8 @@ class _$ChangeSelectedPageImpl implements _ChangeSelectedPage {
     required TResult Function(_ChangeSelectedPage value) changeSelectedPage,
     required TResult Function(_OpenConversation value) openConversation,
     required TResult Function(_StartNewConversation value) startNewConversation,
+    required TResult Function(_OnNewMessagesReceived value)
+        onNewMessagesReceived,
   }) {
     return changeSelectedPage(this);
   }
@@ -335,6 +363,7 @@ class _$ChangeSelectedPageImpl implements _ChangeSelectedPage {
     TResult? Function(_ChangeSelectedPage value)? changeSelectedPage,
     TResult? Function(_OpenConversation value)? openConversation,
     TResult? Function(_StartNewConversation value)? startNewConversation,
+    TResult? Function(_OnNewMessagesReceived value)? onNewMessagesReceived,
   }) {
     return changeSelectedPage?.call(this);
   }
@@ -346,6 +375,7 @@ class _$ChangeSelectedPageImpl implements _ChangeSelectedPage {
     TResult Function(_ChangeSelectedPage value)? changeSelectedPage,
     TResult Function(_OpenConversation value)? openConversation,
     TResult Function(_StartNewConversation value)? startNewConversation,
+    TResult Function(_OnNewMessagesReceived value)? onNewMessagesReceived,
     required TResult orElse(),
   }) {
     if (changeSelectedPage != null) {
@@ -456,6 +486,8 @@ class _$OpenConversationImpl implements _OpenConversation {
             BuildContext context, String conversationId, String userName)
         openConversation,
     required TResult Function() startNewConversation,
+    required TResult Function(List<ConversationModel> conversations)
+        onNewMessagesReceived,
   }) {
     return openConversation(context, conversationId, userName);
   }
@@ -469,6 +501,8 @@ class _$OpenConversationImpl implements _OpenConversation {
             BuildContext context, String conversationId, String userName)?
         openConversation,
     TResult? Function()? startNewConversation,
+    TResult? Function(List<ConversationModel> conversations)?
+        onNewMessagesReceived,
   }) {
     return openConversation?.call(context, conversationId, userName);
   }
@@ -482,6 +516,8 @@ class _$OpenConversationImpl implements _OpenConversation {
             BuildContext context, String conversationId, String userName)?
         openConversation,
     TResult Function()? startNewConversation,
+    TResult Function(List<ConversationModel> conversations)?
+        onNewMessagesReceived,
     required TResult orElse(),
   }) {
     if (openConversation != null) {
@@ -497,6 +533,8 @@ class _$OpenConversationImpl implements _OpenConversation {
     required TResult Function(_ChangeSelectedPage value) changeSelectedPage,
     required TResult Function(_OpenConversation value) openConversation,
     required TResult Function(_StartNewConversation value) startNewConversation,
+    required TResult Function(_OnNewMessagesReceived value)
+        onNewMessagesReceived,
   }) {
     return openConversation(this);
   }
@@ -508,6 +546,7 @@ class _$OpenConversationImpl implements _OpenConversation {
     TResult? Function(_ChangeSelectedPage value)? changeSelectedPage,
     TResult? Function(_OpenConversation value)? openConversation,
     TResult? Function(_StartNewConversation value)? startNewConversation,
+    TResult? Function(_OnNewMessagesReceived value)? onNewMessagesReceived,
   }) {
     return openConversation?.call(this);
   }
@@ -519,6 +558,7 @@ class _$OpenConversationImpl implements _OpenConversation {
     TResult Function(_ChangeSelectedPage value)? changeSelectedPage,
     TResult Function(_OpenConversation value)? openConversation,
     TResult Function(_StartNewConversation value)? startNewConversation,
+    TResult Function(_OnNewMessagesReceived value)? onNewMessagesReceived,
     required TResult orElse(),
   }) {
     if (openConversation != null) {
@@ -587,6 +627,8 @@ class _$StartNewConversationImpl implements _StartNewConversation {
             BuildContext context, String conversationId, String userName)
         openConversation,
     required TResult Function() startNewConversation,
+    required TResult Function(List<ConversationModel> conversations)
+        onNewMessagesReceived,
   }) {
     return startNewConversation();
   }
@@ -600,6 +642,8 @@ class _$StartNewConversationImpl implements _StartNewConversation {
             BuildContext context, String conversationId, String userName)?
         openConversation,
     TResult? Function()? startNewConversation,
+    TResult? Function(List<ConversationModel> conversations)?
+        onNewMessagesReceived,
   }) {
     return startNewConversation?.call();
   }
@@ -613,6 +657,8 @@ class _$StartNewConversationImpl implements _StartNewConversation {
             BuildContext context, String conversationId, String userName)?
         openConversation,
     TResult Function()? startNewConversation,
+    TResult Function(List<ConversationModel> conversations)?
+        onNewMessagesReceived,
     required TResult orElse(),
   }) {
     if (startNewConversation != null) {
@@ -628,6 +674,8 @@ class _$StartNewConversationImpl implements _StartNewConversation {
     required TResult Function(_ChangeSelectedPage value) changeSelectedPage,
     required TResult Function(_OpenConversation value) openConversation,
     required TResult Function(_StartNewConversation value) startNewConversation,
+    required TResult Function(_OnNewMessagesReceived value)
+        onNewMessagesReceived,
   }) {
     return startNewConversation(this);
   }
@@ -639,6 +687,7 @@ class _$StartNewConversationImpl implements _StartNewConversation {
     TResult? Function(_ChangeSelectedPage value)? changeSelectedPage,
     TResult? Function(_OpenConversation value)? openConversation,
     TResult? Function(_StartNewConversation value)? startNewConversation,
+    TResult? Function(_OnNewMessagesReceived value)? onNewMessagesReceived,
   }) {
     return startNewConversation?.call(this);
   }
@@ -650,6 +699,7 @@ class _$StartNewConversationImpl implements _StartNewConversation {
     TResult Function(_ChangeSelectedPage value)? changeSelectedPage,
     TResult Function(_OpenConversation value)? openConversation,
     TResult Function(_StartNewConversation value)? startNewConversation,
+    TResult Function(_OnNewMessagesReceived value)? onNewMessagesReceived,
     required TResult orElse(),
   }) {
     if (startNewConversation != null) {
@@ -661,6 +711,179 @@ class _$StartNewConversationImpl implements _StartNewConversation {
 
 abstract class _StartNewConversation implements ChatEvent {
   const factory _StartNewConversation() = _$StartNewConversationImpl;
+}
+
+/// @nodoc
+abstract class _$$OnNewMessagesReceivedImplCopyWith<$Res> {
+  factory _$$OnNewMessagesReceivedImplCopyWith(
+          _$OnNewMessagesReceivedImpl value,
+          $Res Function(_$OnNewMessagesReceivedImpl) then) =
+      __$$OnNewMessagesReceivedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({List<ConversationModel> conversations});
+}
+
+/// @nodoc
+class __$$OnNewMessagesReceivedImplCopyWithImpl<$Res>
+    extends _$ChatEventCopyWithImpl<$Res, _$OnNewMessagesReceivedImpl>
+    implements _$$OnNewMessagesReceivedImplCopyWith<$Res> {
+  __$$OnNewMessagesReceivedImplCopyWithImpl(_$OnNewMessagesReceivedImpl _value,
+      $Res Function(_$OnNewMessagesReceivedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? conversations = null,
+  }) {
+    return _then(_$OnNewMessagesReceivedImpl(
+      null == conversations
+          ? _value._conversations
+          : conversations // ignore: cast_nullable_to_non_nullable
+              as List<ConversationModel>,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$OnNewMessagesReceivedImpl implements _OnNewMessagesReceived {
+  const _$OnNewMessagesReceivedImpl(final List<ConversationModel> conversations)
+      : _conversations = conversations;
+
+  final List<ConversationModel> _conversations;
+  @override
+  List<ConversationModel> get conversations {
+    if (_conversations is EqualUnmodifiableListView) return _conversations;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_conversations);
+  }
+
+  @override
+  String toString() {
+    return 'ChatEvent.onNewMessagesReceived(conversations: $conversations)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$OnNewMessagesReceivedImpl &&
+            const DeepCollectionEquality()
+                .equals(other._conversations, _conversations));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, const DeepCollectionEquality().hash(_conversations));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$OnNewMessagesReceivedImplCopyWith<_$OnNewMessagesReceivedImpl>
+      get copyWith => __$$OnNewMessagesReceivedImplCopyWithImpl<
+          _$OnNewMessagesReceivedImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() getConversations,
+    required TResult Function(int pageIndex) changeSelectedPage,
+    required TResult Function(
+            BuildContext context, String conversationId, String userName)
+        openConversation,
+    required TResult Function() startNewConversation,
+    required TResult Function(List<ConversationModel> conversations)
+        onNewMessagesReceived,
+  }) {
+    return onNewMessagesReceived(conversations);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? getConversations,
+    TResult? Function(int pageIndex)? changeSelectedPage,
+    TResult? Function(
+            BuildContext context, String conversationId, String userName)?
+        openConversation,
+    TResult? Function()? startNewConversation,
+    TResult? Function(List<ConversationModel> conversations)?
+        onNewMessagesReceived,
+  }) {
+    return onNewMessagesReceived?.call(conversations);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? getConversations,
+    TResult Function(int pageIndex)? changeSelectedPage,
+    TResult Function(
+            BuildContext context, String conversationId, String userName)?
+        openConversation,
+    TResult Function()? startNewConversation,
+    TResult Function(List<ConversationModel> conversations)?
+        onNewMessagesReceived,
+    required TResult orElse(),
+  }) {
+    if (onNewMessagesReceived != null) {
+      return onNewMessagesReceived(conversations);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_GetConversations value) getConversations,
+    required TResult Function(_ChangeSelectedPage value) changeSelectedPage,
+    required TResult Function(_OpenConversation value) openConversation,
+    required TResult Function(_StartNewConversation value) startNewConversation,
+    required TResult Function(_OnNewMessagesReceived value)
+        onNewMessagesReceived,
+  }) {
+    return onNewMessagesReceived(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_GetConversations value)? getConversations,
+    TResult? Function(_ChangeSelectedPage value)? changeSelectedPage,
+    TResult? Function(_OpenConversation value)? openConversation,
+    TResult? Function(_StartNewConversation value)? startNewConversation,
+    TResult? Function(_OnNewMessagesReceived value)? onNewMessagesReceived,
+  }) {
+    return onNewMessagesReceived?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_GetConversations value)? getConversations,
+    TResult Function(_ChangeSelectedPage value)? changeSelectedPage,
+    TResult Function(_OpenConversation value)? openConversation,
+    TResult Function(_StartNewConversation value)? startNewConversation,
+    TResult Function(_OnNewMessagesReceived value)? onNewMessagesReceived,
+    required TResult orElse(),
+  }) {
+    if (onNewMessagesReceived != null) {
+      return onNewMessagesReceived(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _OnNewMessagesReceived implements ChatEvent {
+  const factory _OnNewMessagesReceived(
+          final List<ConversationModel> conversations) =
+      _$OnNewMessagesReceivedImpl;
+
+  List<ConversationModel> get conversations;
+  @JsonKey(ignore: true)
+  _$$OnNewMessagesReceivedImplCopyWith<_$OnNewMessagesReceivedImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc

--- a/mobile_app/lib/features/chat/logic/bloc/chat_event.dart
+++ b/mobile_app/lib/features/chat/logic/bloc/chat_event.dart
@@ -10,4 +10,7 @@ class ChatEvent with _$ChatEvent {
           BuildContext context, String conversationId, String userName) =
       _OpenConversation;
   const factory ChatEvent.startNewConversation() = _StartNewConversation;
+
+  const factory ChatEvent.onNewMessagesReceived(
+      List<ConversationModel> conversations) = _OnNewMessagesReceived;
 }

--- a/mobile_app/lib/main_development.dart
+++ b/mobile_app/lib/main_development.dart
@@ -2,15 +2,16 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 
 import 'chat_app.dart';
+import 'core/di/dependency_injection.dart';
 import 'core/routing/app_router.dart';
 import 'firebase_options.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
+  await setupGetIt();
 
   runApp(ChatApp(appRouter: AppRouter()));
 }

--- a/mobile_app/lib/main_production.dart
+++ b/mobile_app/lib/main_production.dart
@@ -2,6 +2,7 @@
 
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
+import 'package:mobile_app/core/di/dependency_injection.dart';
 import 'package:mobile_app/firebase_options.dart';
 
 import 'chat_app.dart';
@@ -13,6 +14,7 @@ void main() async {
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
+  await setupGetIt();
 
   runApp(ChatApp(appRouter: AppRouter()));
 }


### PR DESCRIPTION

## JiraTicket [FI-9](https://contributors.atlassian.net/jira/software/projects/ATX/boards/6?selectedIssue=ATX-9)

## Description 📑
- integrate chat api functionality using firestore service 

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] 🏗️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Changes

- integrate chat api, using firestore service
- update conversation model to show the 2 user different notification count
- setup dependency injection using getIt
- add new user enum

This pull request includes the following changes:

## Screenshots 📷

| 01                                    | 02                                    |
| ------------------------------------- | ------------------------------------- | 
| <img src="https://github.com/user-attachments/assets/5d4df553-89df-4212-a4f3-1c02c936fcb0" width="100" height="250"> | <img src="https://github.com/user-attachments/assets/bbb2e8dd-08df-46f8-b89e-24721d74d765" width="100" height="250"> |

## How to test 🚦
- run the app, use the + floating action button to create a new conversation wich should be accesible for both pages
- update unseen messages count from firebase, should result in real time updates for the notification icon on the app dynamically for both users